### PR TITLE
Templated boilerplate code

### DIFF
--- a/public/static/css/styles.css
+++ b/public/static/css/styles.css
@@ -238,3 +238,9 @@ action {
 #tiles {
     margin-top:5px;
 }
+
+/* show current page as not a link */
+a[aria-current="page"] {
+    text-decoration: none;
+    color: black;
+}

--- a/views/pages/archive.ejs
+++ b/views/pages/archive.ejs
@@ -1,14 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
 <%- include('components/head.ejs', {path: "archive", title: "archive", description: "blinkies archive - retro blinkie gifs and links to sources. notes on blinkie design and history."}) %>
-
-<body>
-<div id='banner' class='content'>
-blinkies.cafe
-</div>
-<div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | archive<br>
-</div><hr>
 <div class='content'><h1>blinkies archive</h1>
 </div>
 <div id='sourceList' class='archiveContent'>
@@ -136,7 +126,5 @@ blinkies.cafe was born on 2021-10-15.
 </table>
 </div>
 </div>
-<%- include('components/footer.html') %>
-</body>
-</html>
 <script src='/archive.js' type='module'></script>
+<%- include('components/footer.html') %>

--- a/views/pages/archive.ejs
+++ b/views/pages/archive.ejs
@@ -1,19 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>blinkie maker | archive</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='blinkies archive - retro blinkie gifs and links to sources. notes on blinkie design and history.'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/archive">
-  <link rel="stylesheet" type="text/css" href="styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
+<%- include('components/head.ejs', {path: "archive", title: "archive", description: "blinkies archive - retro blinkie gifs and links to sources. notes on blinkie design and history."}) %>
+
 <body>
 <div id='banner' class='content'>
 blinkies.cafe

--- a/views/pages/archive.ejs
+++ b/views/pages/archive.ejs
@@ -1,4 +1,4 @@
-<%- include('components/head.ejs', {path: "archive", title: "archive", description: "blinkies archive - retro blinkie gifs and links to sources. notes on blinkie design and history."}) %>
+<%- include('components/head.ejs', {path: "archive", title: "blinkie maker | archive", description: "blinkies archive - retro blinkie gifs and links to sources. notes on blinkie design and history."}) %>
 <div class='content'><h1>blinkies archive</h1>
 </div>
 <div id='sourceList' class='archiveContent'>

--- a/views/pages/blog.ejs
+++ b/views/pages/blog.ejs
@@ -1,26 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkie thougts: the blinkies.cafe blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='articles on blinkie creation, software development, and digital ephemera in general.'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/blog">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | blog | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include('components/head.ejs', {path: "blog", title: "blinkie thoughts: the blinkies.cafe blog", description: "articles on blinkie creation, software development, and digital ephemera in general."}) %>
 <div class='content'>
     <h1>blinkie thoughts</h1>
 </div>
@@ -32,5 +10,3 @@
     <b>2022-05-14:</b> <a href='/blog/2022-05-14-how-to-make-blinkies'>How to Make Blinkies in Paint</a><br><br>
 </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>
-</html>

--- a/views/pages/blog/2022-05-14-how-to-make-blinkies.ejs
+++ b/views/pages/blog/2022-05-14-how-to-make-blinkies.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>How to Make Blinkies in Paint | the blinkie blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='How to make blinkies from (almost) scratch! All you need is MS paint or any other paint app.'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/blog/2022-05-14-how-to-make-blinkies">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | blog | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include(global.appRoot + '/views/pages/components/head.ejs', {
+    path: "blog/2022-05-14-how-to-make-blinkies",
+    title: "How to Make Blinkies in Paint | the blinkie blog",
+    description: "How to make blinkies from (almost) scratch! All you need is MS paint or any other paint app."
+})%>
 <div class='content'>
     <h1 style='text-align:left;'><a href='/blog'>blog</a> &gt; How to Make Blinkies in Paint</h1>
 </div>
@@ -73,5 +55,3 @@
     </ol>
 </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>
-</html>

--- a/views/pages/blog/2022-06-06-recent-blinkies-feed.ejs
+++ b/views/pages/blog/2022-06-06-recent-blinkies-feed.ejs
@@ -1,16 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>Recent Blinkies Feed out now! | the blinkie blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='Added a live feed of recently generated blinkies!'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/blog/2022-06-06-recent-blinkies-feed">
+<%- include(global.appRoot + '/views/pages/components/head.ejs', {
+    path: "blog/2022-06-06-recent-blinkies-feed",
+    title: "Recent Blinkies Feed out now! | the blinkie blog",
+    description: "Added a live feed of recently generated blinkies!"
+})%>
+  <link rel="canonical" href="https://blinkies.cafe/blog/">
   <link rel="stylesheet" type="text/css" href="/styles.css">
   <meta name="theme-color" content="#4e3075">
 </head>
@@ -34,5 +27,3 @@
     As always, I can't wait to see what people make!!! I might post more feed recordings on <a href='https://graphics-cafe.tumblr.com/'>tumblr</a> :D
 </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>
-</html>

--- a/views/pages/blog/2022-10-29-pixel-font-symbols.ejs
+++ b/views/pages/blog/2022-10-29-pixel-font-symbols.ejs
@@ -1,27 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>hidden symbols in pixel fonts | the blinkie blog</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name='description' content='how to use hidden symbol characters in the blinkies.cafe pixel fonts!'>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
-    <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-    <link rel="canonical" href="https://blinkies.cafe/blog/2022-10-29-pixel-font-symbols">
-    <link rel="stylesheet" type="text/css" href="/styles.css">
-    <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | blog | <a href='/archive'>archive</a><br>
-    </div><hr>
-
+<%- include(global.appRoot + '/views/pages/components/head.ejs', {
+    path: "blog/2022-10-29-pixel-font-symbols",
+    title: "hidden symbols in pixel fonts | the blinkie blog",
+    description: "how to use hidden symbol characters in the blinkies.cafe pixel fonts!"
+})%>
     <!-- edit below this line -->
 
 		<div class='content'>
@@ -103,4 +84,3 @@
             <img src="/blog/2022-10-29-pixel-font-symbols/example11.gif"style='width:150px; height: 20x;' alt="or dont idk blinkie">
         </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>

--- a/views/pages/blog/2022-12-18-blinkie-packs.ejs
+++ b/views/pages/blog/2022-12-18-blinkie-packs.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkies.cafe template releases are changing! | the blinkie blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='We have opened up submissions, and future templates will be released in Blinkie Packs of ~9-18 each.'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/blog/2022-12-18-blinkie-packs">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | blog | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include(global.appRoot + '/views/pages/components/head.ejs', {
+    path: "blog/2022-12-18-blinkie-packs",
+    title: "blinkies.cafe template releases are changing! | the blinkie blog",
+    description: "We have opened up submissions, and future templates will be released in Blinkie Packs of ~9-18 each."
+})%>
     <div class='content'>
         <h1 style='text-align:left;'><a href='/blog'>blog</a> &gt; blinkies.cafe template releases are changing!</h1>
     </div>
@@ -62,5 +44,3 @@
         <p>&#126; Amy</p>
     </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>
-</html>

--- a/views/pages/blog/2023-01-02-seeking-love-templates.ejs
+++ b/views/pages/blog/2023-01-02-seeking-love-templates.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>Seeking "Love" blinkie templates!! | the blinkie blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='blinkies.cafe is seeking blinkie template submissions for our first themed Blinkie Pack, which will be all about love 💝🌹'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/blog/2023-01-02-seeking-love-templates">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | blog | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include(global.appRoot + '/views/pages/components/head.ejs', {
+    path: "blog/2023-01-02-seeking-love-templates",
+    title: "Seeking "Love" blinkie templates!! | the blinkie blog",
+    description: "blinkies.cafe is seeking blinkie template submissions for our first themed Blinkie Pack, which will be all about love 💝🌹"
+})%>
     <div class='content'>
         <h1 style='text-align:left;'><a href='/blog'>blog</a> &gt; Seeking "Love" blinkie templates!</h1>
     </div>
@@ -32,5 +14,3 @@
         <p>If your template is selected, it will be part of the first Blinkie Pack planned for early Feb, in time for Valentine's Day 💌</p>
     </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>
-</html>

--- a/views/pages/cafe.ejs
+++ b/views/pages/cafe.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkie maker | generate blinkie gifs with custom text!</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content="make your own blinkies! browse blinkie styles and add any text you want. blinkies are tiny gifs; they're great badges for your site, stream, blog, or messages. blinkies were popular decorations in early-2000s Geocities-era personal websites.">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/">
-  <link rel="stylesheet" type="text/css" href="styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-<div id='banner' class='content'>
-blinkies.cafe
-</div>
-<div id='navbar' class='content'>
-        generator | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-</div><hr>
+<%- include('components/head.ejs', {
+    path: "", 
+    title: "blinkie maker | generate blinkie gifs with custom text!", 
+    description: "make your own blinkies! browse blinkie styles and add any text you want. blinkies are tiny gifs; they're great badges for your site, stream, blog, or messages. blinkies were popular decorations in early-2000s Geocities-era personal websites."
+}) %>
 <div class='content'>
     <h1>blinkie maker: build a blinkie!</h1>
 </div>
@@ -219,8 +201,6 @@ enjoy~
         <img src="/b/display/y2k-compliant.gif" alt="Y2K-compliant blinkie" class="blinkie">
     </p>
 </div>
-<%- include('components/footer.html') %>
-</body>
-</html>
 <script src='/cafe.js' type='module'></script>
 <script src='/sw.js' type='module'></script>
+<%- include('components/footer.html') %>

--- a/views/pages/components/footer.html
+++ b/views/pages/components/footer.html
@@ -9,3 +9,5 @@
         </tr>
     </table>
 </div>
+</body>
+</html>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -1,5 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <title>blinkie maker | <%=title%></title>
+    <title><%=title%>s</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name='description' content='<%=description%>'>
     <link rel="canonical" href="https://blinkies.cafe/<%=path%>">

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -19,9 +19,9 @@
         blinkies.cafe
     </div>
     <div id='navbar' class='content'>
-        <a href='/' <%=path == '' ? 'aria-current="page"' : ''%>>generator</a> |
-        <a href='/blog' <%=path == 'blog' ? 'aria-current="page"' : ''%>>blog</a> |
-        <a href="/archive" <%=path == 'archive' ? 'aria-current="page"' : ''%>>archive</a>
+        <a href='/' <%=path == '' ? 'aria-current=page' : ''%>>generator</a> |
+        <a href='/blog' <%=path == 'blog' ? 'aria-current=page' : ''%>>blog</a> |
+        <a href="/archive" <%=path == 'archive' ? 'aria-current=page' : ''%>>archive</a>
         <br>
     </div>
     <hr>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title><%=title%>s</title>
+    <title><%=title%></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name='description' content='<%=description%>'>
     <% if (path !== "e404") { %>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -22,7 +22,7 @@
     <link rel="stylesheet" type="text/css" href="<%= typeof stylesheet === 'undefined' ? 'styles.css' : stylesheet%>">
 </head>
 <body>
-    <% if (typeof noHeader !== 'undefined') { if (!noHeader) {%>
+    <% if (typeof noHeader === 'undefined') {%>
     <div id='banner' class='content'>
         blinkies.cafe
     </div>
@@ -33,4 +33,4 @@
         <br>
     </div>
     <hr>
-    <%}}%>
+    <%}%>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <meta name="theme-color" content="#4e3075">
 
-    <link rel="stylesheet" type="text/css" href="<%= typeof stylesheet === 'undefined' ? 'styles.css' : stylesheet%>">
+    <link rel="stylesheet" type="text/css" href="<%= typeof stylesheet === 'undefined' ? '/styles.css' : stylesheet%>">
 </head>
 <body>
     <% if (typeof noHeader === 'undefined') {%>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -1,0 +1,16 @@
+<head>
+    <title>blinkie maker | <%=title%></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name='description' content='<%=description%>'>
+    <link rel="canonical" href="https://blinkies.cafe/<%=path%>">
+
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <meta name="theme-color" content="#4e3075">
+
+    <link rel="stylesheet" type="text/css" href="styles.css">
+</head>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -4,7 +4,9 @@
     <title><%=title%>s</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name='description' content='<%=description%>'>
+    <% if (path !== "e404") { %>
     <link rel="canonical" href="https://blinkies.cafe/<%=path%>">
+    <%}%>
 
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -7,6 +7,9 @@
     <% if (path !== "e404") { %>
     <link rel="canonical" href="https://blinkies.cafe/<%=path%>">
     <%}%>
+    <% if (path === "feed" || path === "wall") {%>
+    <meta name="robots" content="noindex">
+    <%}%>
 
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
@@ -16,9 +19,10 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <meta name="theme-color" content="#4e3075">
 
-    <link rel="stylesheet" type="text/css" href="styles.css">
+    <link rel="stylesheet" type="text/css" href="<%= typeof stylesheet === 'undefined' ? 'styles.css' : stylesheet%>">
 </head>
 <body>
+    <% if (typeof noHeader !== 'undefined') { if (!noHeader) {%>
     <div id='banner' class='content'>
         blinkies.cafe
     </div>
@@ -29,3 +33,4 @@
         <br>
     </div>
     <hr>
+    <%}}%>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -14,3 +14,14 @@
 
     <link rel="stylesheet" type="text/css" href="styles.css">
 </head>
+<body>
+    <div id='banner' class='content'>
+        blinkies.cafe
+    </div>
+    <div id='navbar' class='content'>
+        <a href='/' <%=path == '' ? 'aria-current="page"' : ''%>>generator</a> |
+        <a href='/blog' <%=path == 'blog' ? 'aria-current="page"' : ''%>>blog</a> |
+        <a href="/archive" <%=path == 'archive' ? 'aria-current="page"' : ''%>>archive</a>
+        <br>
+    </div>
+    <hr>

--- a/views/pages/e404.ejs
+++ b/views/pages/e404.ejs
@@ -1,28 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkie maker | error 404</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='blinkie maker - 404 page not found'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include('components/head.ejs', {
+  path: "e404", 
+  title: "blinkie maker | error 404", 
+  description: "blinkie maker - 404 page not found"
+})%>
 <div class='content'>
 <h1>error 404!</h1>
 </div>
 <%- include('components/footer.html') %>
-</body>
-</html>

--- a/views/pages/feed.ejs
+++ b/views/pages/feed.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>the blinkie feed | recently created blinkies!</title>
-  <meta name='description' content="a feed of the 18 latest user-created blinkies.">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include('components/head.ejs', {
+    path: "feed", 
+    title: "the blinkie feed | recently created blinkies!", 
+    description: "a feed of the 18 latest user-created blinkies."
+})%>
 <div class='content'>
     <h1>recently generated blinkies</h1>
 </div>
@@ -58,5 +40,3 @@
     }
 %>
 <%- include('components/footer.html') %>
-</body>
-</html>

--- a/views/pages/halloween.ejs
+++ b/views/pages/halloween.ejs
@@ -1,20 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>halloween blinkies!!</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='spooky scary blinkies for all your festive halloween needs.'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/halloween">
-  <link rel="stylesheet" type="text/css" href="/event/halloween2022.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
+<%- include('components/head.ejs', {
+    path: "halloween", 
+    title: "halloween blinkies!!", 
+    description: "spooky scary blinkies for all your festive halloween needs.",
+    noheader: true,
+    stylesheet: "/event/halloween2022.css"
+})%>
     <%
     if (defaultStyleKey == '') {
     %>
@@ -80,8 +70,6 @@
     <%
     }
     %>
-</body>
-</html>
 <%
 if (defaultStyleKey != '') {
 %>
@@ -89,3 +77,5 @@ if (defaultStyleKey != '') {
 <%
 }
 %>
+</body>
+</html>

--- a/views/pages/pour.ejs
+++ b/views/pages/pour.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkie maker | generate <%=styleList[defaultStyleKey].name%> blinkies!</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='blinkies maker - generate <%=styleList[defaultStyleKey].name%> blinkies with any text you want!'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/pour">
-  <link rel="stylesheet" type="text/css" href="styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-<div id='banner' class='content'>
-blinkies.cafe
-</div>
-<div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-</div><hr>
+<%- include('components/head.ejs', {
+    path: "pour", 
+    title: `blinkie maker | generate ${styleList[defaultStyleKey].name} blinkies!`, 
+    description: `blinkies maker - generate ${styleList[defaultStyleKey].name} blinkies with any text you want!`
+})%>
 <div class='content'>
 <h1><%=styleList[defaultStyleKey].name%> blinkies generator</h1>
 </div>
@@ -56,7 +38,5 @@ text:  &nbsp;<input placeholder='your text here!' name='blinkieText' id='blinkie
 <img id='freshBlinkie' src='/b/display/<%=defaultStyleKey%>.gif' alt='generated blinkie'><br>
 <small id='blinkieLinkHolder'><br><br><br></small>
 </div>
-<%- include('components/footer.html') %>
-</body>
-</html>
 <script src='/pour.js' type='module'></script>
+<%- include('components/footer.html') %>

--- a/views/pages/submitters.ejs
+++ b/views/pages/submitters.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkie template submitters</title>
-  <meta name='description' content="blinkie template credits -- all the blinkies.cafe customizable blinkies, sorted by submitter.">
-  <link rel="canonical" href="https://blinkies.cafe/submitters">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="manifest" href="/site.webmanifest">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" type="text/css" href="styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include('components/head.ejs', {
+    path: "submitters", 
+    title: `blinkie template submitters`, 
+    description: `blinkie template credits -- all the blinkies.cafe customizable blinkies, sorted by submitter.`
+})%>
 <div class='content'>
     <h1>blinkie template submitters</h1>
 </div>
@@ -51,5 +33,3 @@
     </div>
 </div>
 <%- include('components/footer.html') %>
-</body>
-</html>

--- a/views/pages/wall.ejs
+++ b/views/pages/wall.ejs
@@ -1,25 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>the blinkie wall</title>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <meta name="robots" content="noindex">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" type="text/css" href="styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include('components/head.ejs', {
+    path: "wall", 
+    title: "the blinkie wall", 
+    description: "a searchable wall of all our blinkies."
+})%>
 <div class='content'>
     <h1>the blinkie wall</h1>
 </div>
@@ -42,7 +25,5 @@
     </div>
     </center>
 </div>
-<%- include('components/footer.html') %>
 <script src='/wall.js' type='module'></script>
-</body>
-</html>
+<%- include('components/footer.html') %>


### PR DESCRIPTION
Hi hi! A rundown of the changes:
- All boilerplate/common code is now handled by the head & footer templates
- Added a description for wall
- Incidentally fixed some a missing html tag and some outside-body scripts

I can also move some head.ejs logic to router (e.g. no canonical, adding robot noindex), but aside from that this should be ready to merge! Take your time to review. (Oh, and feel free to squash the commits)