### PR TITLE
Accessibility updates

### DIFF
--- a/public/static/css/styles.css
+++ b/public/static/css/styles.css
@@ -244,3 +244,26 @@ a[aria-current="page"] {
     text-decoration: none;
     color: black;
 }
+
+/* Based on https://webaim.org/techniques/css/invisiblecontent/ & https://www.w3schools.com/accessibility/accessibility_skip_links.php */
+.sr-only {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+.skip-link {
+    color: black;
+    background-color: rgb(201,179,230);
+    padding: 5px;
+}
+
+.skip-link:focus {
+    left: 0;
+    top: 0;
+    width: auto;
+    height: auto;
+}

--- a/public/static/css/styles.css
+++ b/public/static/css/styles.css
@@ -238,3 +238,9 @@ action {
 #tiles {
     margin-top:5px;
 }
+
+/* show current page as not a link */
+a[aria-current="page"] {
+    text-decoration: none;
+    color: black;
+}

--- a/public/static/js/archive.js
+++ b/public/static/js/archive.js
@@ -58,13 +58,13 @@ getSourceList().then(function(sourceList){
 
     const nextPage       = document.getElementById("nextPage");
     const prevPage       = document.getElementById("prevPage");
-    nextPage.onclick = function() {
+    onClickOrEnter(nextPage, function() {
         currentPage ++;
         loadStyles(sourceArray, currentPage);
-    }
-    prevPage.onclick = function() {
+    });
+    onClickOrEnter(prevPage, function() {
         currentPage --;
         loadStyles(sourceArray, currentPage);
-    }
+    });
 
 });

--- a/public/static/js/cafe.js
+++ b/public/static/js/cafe.js
@@ -60,7 +60,7 @@ function loadStyles (styleList, styleOrder, currentPage, firstLoad) {
         // if page has enough blinkies to populate tile, update the tile.
         if (i < stylePage.length) {
             const styleID            = stylePage[i][0];
-            blinkieTiles[i].onclick  = function() { selectStyle(styleList, styleID); }
+            onClickOrEnter(blinkieTiles[i], function() { selectStyle(styleList, styleID); });
             blinkieTiles[i].style.visibility = '';
             if (!firstLoad) {
                 blinkieTiles[i].src      = '/b/display/' + styleID + '.' + blinkieExt;
@@ -247,13 +247,13 @@ getStyleList().then(function(styleList){
     const selectTags     = document.getElementById("selectTags");
 
     let toggleFreeze = document.getElementById("toggleFreeze");
-    toggleFreeze.onclick = function () {
+    onClickOrEnter(toggleFreeze, function () {
         let url = new URL(document.location.href)
         if (toggleFreeze.checked) url.searchParams.set('freeze',1);
         else url.searchParams.delete('freeze')
         window.history.pushState('',document.title,url);
         loadStyles(styleList, styleOrder, global.currentPage, false);
-    }
+    });
 
     let tags = []
     document.querySelectorAll(".tag").forEach(tag => tags.push(tag.value));
@@ -273,33 +273,33 @@ getStyleList().then(function(styleList){
         global.currentPage = 1;
         loadStyles(styleList, styleOrder, global.currentPage, false);
     }
-    sortNew.onclick = function() {
+    onClickOrEnter(sortNew, function() {
         if (currentSort != 'bdaydesc') {
             styleOrder = sortStyles(styleList,'bday', 'desc');
             global.currentPage = 1;
             loadStyles(styleList, styleOrder, global.currentPage, false);
         }
-    }
-    sortOld.onclick = function() {
+    });
+    onClickOrEnter(sortOld, function() {
         if (currentSort != 'bdayasc') {
             styleOrder = sortStyles(styleList,'bday', 'asc');
             global.currentPage = 1;
             loadStyles(styleList, styleOrder, global.currentPage, false);
         }
-    }
-    sortRandom.onclick = function() {
+    });
+    onClickOrEnter(sortRandom, function() {
         styleOrder = shuffleStyles(styleList);
         global.currentPage = 1;
         loadStyles(styleList, styleOrder, global.currentPage, false);
-    }
-    nextPage.onclick = function() {
+    });
+    onClickOrEnter(nextPage, function() {
         global.currentPage ++;
         loadStyles(styleList, styleOrder, global.currentPage, false);
-    }
-    prevPage.onclick = function() {
+    });
+    onClickOrEnter(prevPage, function() {
         global.currentPage --;
         loadStyles(styleList, styleOrder, global.currentPage, false);
-    }
+    });
 });
 
 document.getElementById("blinkieForm").addEventListener("submit", submit);
@@ -307,7 +307,7 @@ document.getElementById("blinkieText").addEventListener("keypress", enterSubmit)
 document.getElementById("blinkieStyle").addEventListener("keypress", enterSubmit);
 document.getElementById("blinkieScale").addEventListener("keypress", enterSubmit);
 
-document.getElementById("backToGalleryBtn").onclick = function() {
+onClickOrEnter(document.getElementById("backToGalleryBtn"), function() {
     let gallery = document.getElementById("gallery");
     let pour = document.getElementById("pour");
     gallery.style.visibility = '';
@@ -316,11 +316,11 @@ document.getElementById("backToGalleryBtn").onclick = function() {
     let url = new URL(document.location.href)
     url.searchParams.delete('s');
     window.history.pushState('',document.title,url);
-}
+});
 
 const symbolToggle = document.getElementById("symbolToggle");
 const symbolTable = document.getElementById("symbolTable");
-symbolToggle.onclick = function() {
+onClickOrEnter(symbolToggle, function() {
     if (symbolTable.style.visibility == 'hidden') {
         symbolTable.style.visibility = '';
         symbolToggle.innerText = 'hide symbols ▴';
@@ -329,17 +329,17 @@ symbolToggle.onclick = function() {
         symbolTable.style.visibility = 'hidden';
         symbolToggle.innerText = 'show symbols ▾';
     }
-}
+});
 
 let symbolButtons = document.querySelectorAll(".symbolButton");
 symbolButtons.forEach(function(button){
-    button.onclick = function() {
-        insertAtCaret('blinkieText',button.innerText);
-    }
+    onClickOrEnter(button, function(e) {
+        insertAtCaret('blinkieText',button.innerText, e.type != "keyup");
+    });
 });
 
 // https://web.archive.org/web/20110102112946/http://http://www.scottklarr.com/topic/425/how-to-insert-text-into-a-textarea-where-the-cursor-is/
-function insertAtCaret(areaId,text) {
+function insertAtCaret(areaId,text,focus=false) {
     var txtarea = document.getElementById(areaId);
     var scrollPos = txtarea.scrollTop;
     var strPos = 0;
@@ -347,7 +347,7 @@ function insertAtCaret(areaId,text) {
         "ff" : (document.selection ? "ie" : false ) );
     var range;
     if (br == "ie") {
-        txtarea.focus();
+        if (focus) { txtarea.focus(); }
         range = document.selection.createRange();
         range.moveStart ('character', -txtarea.value.length);
         strPos = range.text.length;
@@ -359,7 +359,7 @@ function insertAtCaret(areaId,text) {
     txtarea.value=front+text+back;
     strPos = strPos + text.length;
     if (br == "ie") {
-        txtarea.focus();
+        if (focus) { txtarea.fo-cus(); }
         range = document.selection.createRange();
         range.moveStart ('character', -txtarea.value.length);
         range.moveStart ('character', strPos);
@@ -369,7 +369,7 @@ function insertAtCaret(areaId,text) {
     else if (br == "ff") {
         txtarea.selectionStart = strPos;
         txtarea.selectionEnd = strPos;
-        txtarea.focus();
+        if (focus) { txtarea.focus(); }        
     }
     txtarea.scrollTop = scrollPos;
 }
@@ -383,10 +383,7 @@ function queryWall (queryString) {
 }
 const queryText   = document.getElementById("queryText");
 const queryAction = document.getElementById("queryAction");
-queryAction.onclick = function () { queryWall(queryText.value); }
-queryText.addEventListener("keypress", function (event) {
-    if(event.key === 'Enter') queryWall(queryText.value);
-});
+onClickOrEnter(queryAction, function () { queryWall(queryText.value); });
 
 document.getElementById("badgetxt").onclick = function() {
     this.focus();

--- a/public/static/js/utils.js
+++ b/public/static/js/utils.js
@@ -1,0 +1,8 @@
+function onClickOrEnter(element, func) {
+    element.onclick = func;
+    element.onkeyup = function(e) {
+        if (e.key == "Enter") {
+            func(e);
+        }
+    }
+}

--- a/public/static/js/wall.js
+++ b/public/static/js/wall.js
@@ -14,9 +14,9 @@ function searchBlinkies() {
     }
 }
 
-document.getElementById("backToGalleryBtn").onclick = function() {
+onClickOrEnter(document.getElementById("backToGalleryBtn"), function() {
     history.back();
-}
+});
 
 search.addEventListener("input", searchBlinkies);
 search.addEventListener("keyup", searchBlinkies);

--- a/views/pages/archive.ejs
+++ b/views/pages/archive.ejs
@@ -1,14 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
 <%- include('components/head.ejs', {path: "archive", title: "archive", description: "blinkies archive - retro blinkie gifs and links to sources. notes on blinkie design and history."}) %>
-
-<body>
-<div id='banner' class='content'>
-blinkies.cafe
-</div>
-<div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | archive<br>
-</div><hr>
 <div class='content'><h1>blinkies archive</h1>
 </div>
 <div id='sourceList' class='archiveContent'>
@@ -136,7 +126,5 @@ blinkies.cafe was born on 2021-10-15.
 </table>
 </div>
 </div>
-<%- include('components/footer.html') %>
-</body>
-</html>
 <script src='/archive.js' type='module'></script>
+<%- include('components/footer.html') %>

--- a/views/pages/archive.ejs
+++ b/views/pages/archive.ejs
@@ -1,19 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>blinkie maker | archive</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='blinkies archive - retro blinkie gifs and links to sources. notes on blinkie design and history.'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/archive">
-  <link rel="stylesheet" type="text/css" href="styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
+<%- include('components/head.ejs', {path: "archive", title: "archive", description: "blinkies archive - retro blinkie gifs and links to sources. notes on blinkie design and history."}) %>
+
 <body>
 <div id='banner' class='content'>
 blinkies.cafe

--- a/views/pages/archive.ejs
+++ b/views/pages/archive.ejs
@@ -1,4 +1,4 @@
-<%- include('components/head.ejs', {path: "archive", title: "archive", description: "blinkies archive - retro blinkie gifs and links to sources. notes on blinkie design and history."}) %>
+<%- include('components/head.ejs', {path: "archive", title: "blinkie maker | archive", description: "blinkies archive - retro blinkie gifs and links to sources. notes on blinkie design and history."}) %>
 <div class='content'><h1>blinkies archive</h1>
 </div>
 <div id='sourceList' class='archiveContent'>

--- a/views/pages/archive.ejs
+++ b/views/pages/archive.ejs
@@ -38,9 +38,9 @@ the archived copies live here, with links to their sources and generator pages. 
 </table>
 <center>
 <galleryUI id='pagenav'>
-    <action id='prevPage' style='visibility:hidden'>&lt;==</action>
+    <action tabindex="0" id='prevPage' style='visibility:hidden'>&lt;==</action>
     <actionLabel id='currPage'> 1 </actionLabel>
-    <action id='nextPage'>==&gt;</action>
+    <action tabindex="0" id='nextPage'>==&gt;</action>
 </galleryUI>
 </center>
 </div>

--- a/views/pages/blog.ejs
+++ b/views/pages/blog.ejs
@@ -1,26 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkie thougts: the blinkies.cafe blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='articles on blinkie creation, software development, and digital ephemera in general.'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/blog">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | blog | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include('components/head.ejs', {path: "blog", title: "blinkie thoughts: the blinkies.cafe blog", description: "articles on blinkie creation, software development, and digital ephemera in general."}) %>
 <div class='content'>
     <h1>blinkie thoughts</h1>
 </div>
@@ -32,5 +10,3 @@
     <b>2022-05-14:</b> <a href='/blog/2022-05-14-how-to-make-blinkies'>How to Make Blinkies in Paint</a><br><br>
 </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>
-</html>

--- a/views/pages/blog/2022-05-14-how-to-make-blinkies.ejs
+++ b/views/pages/blog/2022-05-14-how-to-make-blinkies.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>How to Make Blinkies in Paint | the blinkie blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='How to make blinkies from (almost) scratch! All you need is MS paint or any other paint app.'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/blog/2022-05-14-how-to-make-blinkies">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | blog | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include(global.appRoot + '/views/pages/components/head.ejs', {
+    path: "blog/2022-05-14-how-to-make-blinkies",
+    title: "How to Make Blinkies in Paint | the blinkie blog",
+    description: "How to make blinkies from (almost) scratch! All you need is MS paint or any other paint app."
+})%>
 <div class='content'>
     <h1 style='text-align:left;'><a href='/blog'>blog</a> &gt; How to Make Blinkies in Paint</h1>
 </div>
@@ -73,5 +55,3 @@
     </ol>
 </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>
-</html>

--- a/views/pages/blog/2022-06-06-recent-blinkies-feed.ejs
+++ b/views/pages/blog/2022-06-06-recent-blinkies-feed.ejs
@@ -1,16 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>Recent Blinkies Feed out now! | the blinkie blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='Added a live feed of recently generated blinkies!'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/blog/2022-06-06-recent-blinkies-feed">
+<%- include(global.appRoot + '/views/pages/components/head.ejs', {
+    path: "blog/2022-06-06-recent-blinkies-feed",
+    title: "Recent Blinkies Feed out now! | the blinkie blog",
+    description: "Added a live feed of recently generated blinkies!"
+})%>
+  <link rel="canonical" href="https://blinkies.cafe/blog/">
   <link rel="stylesheet" type="text/css" href="/styles.css">
   <meta name="theme-color" content="#4e3075">
 </head>
@@ -34,5 +27,3 @@
     As always, I can't wait to see what people make!!! I might post more feed recordings on <a href='https://graphics-cafe.tumblr.com/'>tumblr</a> :D
 </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>
-</html>

--- a/views/pages/blog/2022-10-29-pixel-font-symbols.ejs
+++ b/views/pages/blog/2022-10-29-pixel-font-symbols.ejs
@@ -1,27 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>hidden symbols in pixel fonts | the blinkie blog</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name='description' content='how to use hidden symbol characters in the blinkies.cafe pixel fonts!'>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
-    <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-    <link rel="canonical" href="https://blinkies.cafe/blog/2022-10-29-pixel-font-symbols">
-    <link rel="stylesheet" type="text/css" href="/styles.css">
-    <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | blog | <a href='/archive'>archive</a><br>
-    </div><hr>
-
+<%- include(global.appRoot + '/views/pages/components/head.ejs', {
+    path: "blog/2022-10-29-pixel-font-symbols",
+    title: "hidden symbols in pixel fonts | the blinkie blog",
+    description: "how to use hidden symbol characters in the blinkies.cafe pixel fonts!"
+})%>
     <!-- edit below this line -->
 
 		<div class='content'>
@@ -103,4 +84,3 @@
             <img src="/blog/2022-10-29-pixel-font-symbols/example11.gif"style='width:150px; height: 20x;' alt="or dont idk blinkie">
         </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>

--- a/views/pages/blog/2022-12-18-blinkie-packs.ejs
+++ b/views/pages/blog/2022-12-18-blinkie-packs.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkies.cafe template releases are changing! | the blinkie blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='We have opened up submissions, and future templates will be released in Blinkie Packs of ~9-18 each.'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/blog/2022-12-18-blinkie-packs">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | blog | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include(global.appRoot + '/views/pages/components/head.ejs', {
+    path: "blog/2022-12-18-blinkie-packs",
+    title: "blinkies.cafe template releases are changing! | the blinkie blog",
+    description: "We have opened up submissions, and future templates will be released in Blinkie Packs of ~9-18 each."
+})%>
     <div class='content'>
         <h1 style='text-align:left;'><a href='/blog'>blog</a> &gt; blinkies.cafe template releases are changing!</h1>
     </div>
@@ -62,5 +44,3 @@
         <p>&#126; Amy</p>
     </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>
-</html>

--- a/views/pages/blog/2023-01-02-seeking-love-templates.ejs
+++ b/views/pages/blog/2023-01-02-seeking-love-templates.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>Seeking "Love" blinkie templates!! | the blinkie blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='blinkies.cafe is seeking blinkie template submissions for our first themed Blinkie Pack, which will be all about love 💝🌹'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/blog/2023-01-02-seeking-love-templates">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | blog | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include(global.appRoot + '/views/pages/components/head.ejs', {
+    path: "blog/2023-01-02-seeking-love-templates",
+    title: "Seeking "Love" blinkie templates!! | the blinkie blog",
+    description: "blinkies.cafe is seeking blinkie template submissions for our first themed Blinkie Pack, which will be all about love 💝🌹"
+})%>
     <div class='content'>
         <h1 style='text-align:left;'><a href='/blog'>blog</a> &gt; Seeking "Love" blinkie templates!</h1>
     </div>
@@ -32,5 +14,3 @@
         <p>If your template is selected, it will be part of the first Blinkie Pack planned for early Feb, in time for Valentine's Day 💌</p>
     </div>
 <%- include(global.appRoot + '/views/pages/components/footer.html') %>
-</body>
-</html>

--- a/views/pages/cafe.ejs
+++ b/views/pages/cafe.ejs
@@ -9,7 +9,7 @@
 <div class='content'>
     <div class='divider'></div>
     <div id='pour' style='position:absolute; visibility:<%if (pourStyle == '') {%>hidden<%} else {%>visible<%}%>'>
-        <action id='backToGalleryBtn'>&#60; back to gallery</action><br><br>
+        <action tabindex="0" id='backToGalleryBtn'>&#60; back to gallery</action><br><br>
         <form id='blinkieForm'>
             <div>
                 text:  &nbsp;<input placeholder='your text here!' name='blinkieText' id='blinkieText' rows=1 wrap='off' type='text' autocomplete="off">&nbsp;<input type="checkbox" id="toggleSplit" name="toggleSplit"><label for="toggleSplit">split</label>(<div class="tooltip">?
@@ -17,14 +17,14 @@
                 </div>)
             </div>
             <div id='symbolBox' style='margin-left:60px;'>
-                <action id='symbolToggle'>show symbols ▾</action><br>
+                <action tabindex="0" id='symbolToggle'>show symbols ▾</action><br>
                 <span id='symbolTable' style='visibility:hidden;z-index:1;'>
                     <table>
-                        <tr><td class='symbolButton'>♥</td><td class='symbolButton'>♡</td><td class='symbolButton'>♠</td><td class='symbolButton'>♣</td></tr>
-                        <tr><td class='symbolButton'>♦</td><td class='symbolButton'>🦀</td><td class='symbolButton'>🐈</td><td class='symbolButton'>👽</td></tr>
-                        <tr><td class='symbolButton'>🙂</td><td class='symbolButton'>👀</td><td class='symbolButton'>😐</td><td class='symbolButton'>💀</td></tr>
-                        <tr><td class='symbolButton'>🌼</td><td class='symbolButton'>☎</td><td class='symbolButton'>👑</td><td class='symbolButton'>☮</td></tr>
-                        <tr><td class='symbolButton'>✖</td><td class='symbolButton'>♩</td><td class='symbolButton'>♪</td><td class='symbolButton'>♫</td></tr>
+                        <tr><td class='symbolButton' role='button' tabindex='0'>♥</td><td class='symbolButton' role='button' tabindex='0'>♡</td><td class='symbolButton' role='button' tabindex='0'>♠</td><td class='symbolButton' role='button' tabindex='0'>♣</td></tr>
+                        <tr><td class='symbolButton' role='button' tabindex='0'>♦</td><td class='symbolButton' role='button' tabindex='0'>🦀</td><td class='symbolButton' role='button' tabindex='0'>🐈</td><td class='symbolButton' role='button' tabindex='0'>👽</td></tr>
+                        <tr><td class='symbolButton' role='button' tabindex='0'>🙂</td><td class='symbolButton' role='button' tabindex='0'>👀</td><td class='symbolButton' role='button' tabindex='0'>😐</td><td class='symbolButton' role='button' tabindex='0'>💀</td></tr>
+                        <tr><td class='symbolButton' role='button' tabindex='0'>🌼</td><td class='symbolButton' role='button' tabindex='0'>☎</td><td class='symbolButton' role='button' tabindex='0'>👑</td><td class='symbolButton' role='button' tabindex='0'>☮</td></tr>
+                        <tr><td class='symbolButton' role='button' tabindex='0'>✖</td><td class='symbolButton' role='button' tabindex='0'>♩</td><td class='symbolButton' role='button' tabindex='0'>♪</td><td class='symbolButton' role='button' tabindex='0'>♫</td></tr>
                     </table>
                 </span>
             </div>
@@ -76,8 +76,8 @@
     <div id='gallery' type='text' style='position:relative; z-index:0; visibility:<%if (pourStyle == '') {%><%} else {%>hidden<%}%>'>
         click a blinkie to customize!<br><br>
         <galleryUI>
-            search: <input type="text" id="queryText" style="width:135px;margin-bottom:8px;" placeholder="text, tags, name">&nbsp;<action id='queryAction'>go &gt;</action><br>
-            sort:&nbsp;<action id='sortNew'>new</action> <action id='sortRandom'>random</action> <action id='sortOld'>old</action><br>
+            search: <input type="text" id="queryText" style="width:135px;margin-bottom:8px;" placeholder="text, tags, name">&nbsp;<action tabindex="0" id='queryAction'>go &gt;</action><br>
+            sort:&nbsp;<action tabindex="0" id='sortNew'>new</action> <action tabindex="0" id='sortRandom'>random</action> <action tabindex="0" id='sortOld'>old</action><br>
             tags:&nbsp;<select id='selectTags' style='width:100px;margin-top:8px;'>
                 <option class='tag' value='all'>all</option>
                 <option class='tag' value='2024may'>May 2024: cute stuff</option>
@@ -113,15 +113,15 @@
             <%
             const blinkieExt = freeze ? 'png' : 'gif';
             for (const [key, value] of Object.entries(stylePage)) {
-                %><img src="/b/display/<%=key%>.<%=blinkieExt%>" alt="<%=value.name%> blinkie" class="blinkie blinkieTile"><%
+                %><img tabindex="0" role="button" src="/b/display/<%=key%>.<%=blinkieExt%>" alt="<%=value.name%> blinkie" class="blinkie blinkieTile"><%
             }
             %>
         </center>
         <center>
             <galleryUI id='pagenav'>
-                <img id='prevPage' src='/arrow-left.gif' class='clickable' style='width:24px;height:13px;visibility:hidden;' alt="previous page">
+                <img tabindex="0" role="button" id='prevPage' src='/arrow-left.gif' class='clickable' style='width:24px;height:13px;visibility:hidden;' alt="previous page">
                 <b><actionLabel id='currPage'> 1 </actionLabel></b>
-                <img id='nextPage' src='/arrow-right.gif' class='clickable' style='width:24px;height:13px;' alt="next page">
+                <img tabindex="0" role="button" id='nextPage' src='/arrow-right.gif' class='clickable' style='width:24px;height:13px;' alt="next page">
             </galleryUI>
         </center>
         <br>

--- a/views/pages/cafe.ejs
+++ b/views/pages/cafe.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkie maker | generate blinkie gifs with custom text!</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content="make your own blinkies! browse blinkie styles and add any text you want. blinkies are tiny gifs; they're great badges for your site, stream, blog, or messages. blinkies were popular decorations in early-2000s Geocities-era personal websites.">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/">
-  <link rel="stylesheet" type="text/css" href="styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-<div id='banner' class='content'>
-blinkies.cafe
-</div>
-<div id='navbar' class='content'>
-        generator | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-</div><hr>
+<%- include('components/head.ejs', {
+    path: "", 
+    title: "blinkie maker | generate blinkie gifs with custom text!", 
+    description: "make your own blinkies! browse blinkie styles and add any text you want. blinkies are tiny gifs; they're great badges for your site, stream, blog, or messages. blinkies were popular decorations in early-2000s Geocities-era personal websites."
+}) %>
 <div class='content'>
     <h1>blinkie maker: build a blinkie!</h1>
 </div>
@@ -219,8 +201,6 @@ enjoy~
         <img src="/b/display/y2k-compliant.gif" alt="Y2K-compliant blinkie" class="blinkie">
     </p>
 </div>
-<%- include('components/footer.html') %>
-</body>
-</html>
 <script src='/cafe.js' type='module'></script>
 <script src='/sw.js' type='module'></script>
+<%- include('components/footer.html') %>

--- a/views/pages/components/footer.html
+++ b/views/pages/components/footer.html
@@ -1,4 +1,5 @@
-<div id='footer' class='content smalltext'>
+</main>
+<footer id='footer' class='content smalltext'>
     <table>
         <tr>
             <td><img id="bc-char" src="/bc-char.gif" alt="bc -- blinkies.cafe">&nbsp;&nbsp;</td>
@@ -8,6 +9,6 @@
             by amy &#60;3</td>
         </tr>
     </table>
-</div>
+</footer>
 </body>
 </html>

--- a/views/pages/components/footer.html
+++ b/views/pages/components/footer.html
@@ -9,3 +9,5 @@
         </tr>
     </table>
 </div>
+</body>
+</html>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -1,5 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <title>blinkie maker | <%=title%></title>
+    <title><%=title%>s</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name='description' content='<%=description%>'>
     <link rel="canonical" href="https://blinkies.cafe/<%=path%>">

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -19,9 +19,9 @@
         blinkies.cafe
     </div>
     <div id='navbar' class='content'>
-        <a href='/' <%=path == '' ? 'aria-current="page"' : ''%>>generator</a> |
-        <a href='/blog' <%=path == 'blog' ? 'aria-current="page"' : ''%>>blog</a> |
-        <a href="/archive" <%=path == 'archive' ? 'aria-current="page"' : ''%>>archive</a>
+        <a href='/' <%=path == '' ? 'aria-current=page' : ''%>>generator</a> |
+        <a href='/blog' <%=path == 'blog' ? 'aria-current=page' : ''%>>blog</a> |
+        <a href="/archive" <%=path == 'archive' ? 'aria-current=page' : ''%>>archive</a>
         <br>
     </div>
     <hr>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -20,6 +20,7 @@
     <meta name="theme-color" content="#4e3075">
 
     <link rel="stylesheet" type="text/css" href="<%= typeof stylesheet === 'undefined' ? '/styles.css' : stylesheet%>">
+    <script src='/utils.js'></script>
 </head>
 <body>
     <a href="#main" class="sr-only skip-link">Skip to content!</a>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title><%=title%>s</title>
+    <title><%=title%></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name='description' content='<%=description%>'>
     <% if (path !== "e404") { %>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -22,7 +22,7 @@
     <link rel="stylesheet" type="text/css" href="<%= typeof stylesheet === 'undefined' ? 'styles.css' : stylesheet%>">
 </head>
 <body>
-    <% if (typeof noHeader !== 'undefined') { if (!noHeader) {%>
+    <% if (typeof noHeader === 'undefined') {%>
     <div id='banner' class='content'>
         blinkies.cafe
     </div>
@@ -33,4 +33,4 @@
         <br>
     </div>
     <hr>
-    <%}}%>
+    <%}%>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <meta name="theme-color" content="#4e3075">
 
-    <link rel="stylesheet" type="text/css" href="<%= typeof stylesheet === 'undefined' ? 'styles.css' : stylesheet%>">
+    <link rel="stylesheet" type="text/css" href="<%= typeof stylesheet === 'undefined' ? '/styles.css' : stylesheet%>">
 </head>
 <body>
     <% if (typeof noHeader === 'undefined') {%>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -1,0 +1,16 @@
+<head>
+    <title>blinkie maker | <%=title%></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name='description' content='<%=description%>'>
+    <link rel="canonical" href="https://blinkies.cafe/<%=path%>">
+
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <meta name="theme-color" content="#4e3075">
+
+    <link rel="stylesheet" type="text/css" href="styles.css">
+</head>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -22,15 +22,17 @@
     <link rel="stylesheet" type="text/css" href="<%= typeof stylesheet === 'undefined' ? '/styles.css' : stylesheet%>">
 </head>
 <body>
+    <a href="#main" class="sr-only skip-link">Skip to content!</a>
     <% if (typeof noHeader === 'undefined') {%>
-    <div id='banner' class='content'>
+    <header id='banner' class='content'>
         blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
+    </header>
+    <nav id='navbar' class='content'>
         <a href='/' <%=path == '' ? 'aria-current=page' : ''%>>generator</a> |
         <a href='/blog' <%=path == 'blog' ? 'aria-current=page' : ''%>>blog</a> |
         <a href="/archive" <%=path == 'archive' ? 'aria-current=page' : ''%>>archive</a>
         <br>
-    </div>
+    </nav>
     <hr>
     <%}%>
+    <main id="main">

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -4,7 +4,9 @@
     <title><%=title%>s</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name='description' content='<%=description%>'>
+    <% if (path !== "e404") { %>
     <link rel="canonical" href="https://blinkies.cafe/<%=path%>">
+    <%}%>
 
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -7,6 +7,9 @@
     <% if (path !== "e404") { %>
     <link rel="canonical" href="https://blinkies.cafe/<%=path%>">
     <%}%>
+    <% if (path === "feed" || path === "wall") {%>
+    <meta name="robots" content="noindex">
+    <%}%>
 
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
@@ -16,9 +19,10 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <meta name="theme-color" content="#4e3075">
 
-    <link rel="stylesheet" type="text/css" href="styles.css">
+    <link rel="stylesheet" type="text/css" href="<%= typeof stylesheet === 'undefined' ? 'styles.css' : stylesheet%>">
 </head>
 <body>
+    <% if (typeof noHeader !== 'undefined') { if (!noHeader) {%>
     <div id='banner' class='content'>
         blinkies.cafe
     </div>
@@ -29,3 +33,4 @@
         <br>
     </div>
     <hr>
+    <%}}%>

--- a/views/pages/components/head.ejs
+++ b/views/pages/components/head.ejs
@@ -14,3 +14,14 @@
 
     <link rel="stylesheet" type="text/css" href="styles.css">
 </head>
+<body>
+    <div id='banner' class='content'>
+        blinkies.cafe
+    </div>
+    <div id='navbar' class='content'>
+        <a href='/' <%=path == '' ? 'aria-current="page"' : ''%>>generator</a> |
+        <a href='/blog' <%=path == 'blog' ? 'aria-current="page"' : ''%>>blog</a> |
+        <a href="/archive" <%=path == 'archive' ? 'aria-current="page"' : ''%>>archive</a>
+        <br>
+    </div>
+    <hr>

--- a/views/pages/e404.ejs
+++ b/views/pages/e404.ejs
@@ -1,28 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkie maker | error 404</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='blinkie maker - 404 page not found'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include('components/head.ejs', {
+  path: "e404", 
+  title: "blinkie maker | error 404", 
+  description: "blinkie maker - 404 page not found"
+})%>
 <div class='content'>
 <h1>error 404!</h1>
 </div>
 <%- include('components/footer.html') %>
-</body>
-</html>

--- a/views/pages/feed.ejs
+++ b/views/pages/feed.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>the blinkie feed | recently created blinkies!</title>
-  <meta name='description' content="a feed of the 18 latest user-created blinkies.">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex">
-  <link rel="stylesheet" type="text/css" href="/styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include('components/head.ejs', {
+    path: "feed", 
+    title: "the blinkie feed | recently created blinkies!", 
+    description: "a feed of the 18 latest user-created blinkies."
+})%>
 <div class='content'>
     <h1>recently generated blinkies</h1>
 </div>
@@ -58,5 +40,3 @@
     }
 %>
 <%- include('components/footer.html') %>
-</body>
-</html>

--- a/views/pages/halloween.ejs
+++ b/views/pages/halloween.ejs
@@ -1,20 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>halloween blinkies!!</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='spooky scary blinkies for all your festive halloween needs.'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/halloween">
-  <link rel="stylesheet" type="text/css" href="/event/halloween2022.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
+<%- include('components/head.ejs', {
+    path: "halloween", 
+    title: "halloween blinkies!!", 
+    description: "spooky scary blinkies for all your festive halloween needs.",
+    noheader: true,
+    stylesheet: "/event/halloween2022.css"
+})%>
     <%
     if (defaultStyleKey == '') {
     %>
@@ -80,8 +70,6 @@
     <%
     }
     %>
-</body>
-</html>
 <%
 if (defaultStyleKey != '') {
 %>
@@ -89,3 +77,5 @@ if (defaultStyleKey != '') {
 <%
 }
 %>
+</body>
+</html>

--- a/views/pages/pour.ejs
+++ b/views/pages/pour.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkie maker | generate <%=styleList[defaultStyleKey].name%> blinkies!</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name='description' content='blinkies maker - generate <%=styleList[defaultStyleKey].name%> blinkies with any text you want!'>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="canonical" href="https://blinkies.cafe/pour">
-  <link rel="stylesheet" type="text/css" href="styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-<div id='banner' class='content'>
-blinkies.cafe
-</div>
-<div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-</div><hr>
+<%- include('components/head.ejs', {
+    path: "pour", 
+    title: `blinkie maker | generate ${styleList[defaultStyleKey].name} blinkies!`, 
+    description: `blinkies maker - generate ${styleList[defaultStyleKey].name} blinkies with any text you want!`
+})%>
 <div class='content'>
 <h1><%=styleList[defaultStyleKey].name%> blinkies generator</h1>
 </div>
@@ -56,7 +38,5 @@ text:  &nbsp;<input placeholder='your text here!' name='blinkieText' id='blinkie
 <img id='freshBlinkie' src='/b/display/<%=defaultStyleKey%>.gif' alt='generated blinkie'><br>
 <small id='blinkieLinkHolder'><br><br><br></small>
 </div>
-<%- include('components/footer.html') %>
-</body>
-</html>
 <script src='/pour.js' type='module'></script>
+<%- include('components/footer.html') %>

--- a/views/pages/submitters.ejs
+++ b/views/pages/submitters.ejs
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>blinkie template submitters</title>
-  <meta name='description' content="blinkie template credits -- all the blinkies.cafe customizable blinkies, sorted by submitter.">
-  <link rel="canonical" href="https://blinkies.cafe/submitters">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="manifest" href="/site.webmanifest">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" type="text/css" href="styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include('components/head.ejs', {
+    path: "submitters", 
+    title: `blinkie template submitters`, 
+    description: `blinkie template credits -- all the blinkies.cafe customizable blinkies, sorted by submitter.`
+})%>
 <div class='content'>
     <h1>blinkie template submitters</h1>
 </div>
@@ -51,5 +33,3 @@
     </div>
 </div>
 <%- include('components/footer.html') %>
-</body>
-</html>

--- a/views/pages/wall.ejs
+++ b/views/pages/wall.ejs
@@ -9,7 +9,7 @@
 <div class='content'>
     <center>
     <div id='gallery' type='text' style='position:relative; z-index:0; visibility:'>
-        <action id='backToGalleryBtn'>&#60; back to gallery</action><br><br>
+        <action tabindex="0" id='backToGalleryBtn'>&#60; back to gallery</action><br><br>
         search templates: <input type="text" id="search" style="width:225px;" placeholder="name, tags, or default text" value="<%=query%>"><br>
         click a blinkie to customize c:<br>
         <center id='tiles'>

--- a/views/pages/wall.ejs
+++ b/views/pages/wall.ejs
@@ -1,25 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>the blinkie wall</title>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-  <meta name="robots" content="noindex">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" type="text/css" href="styles.css">
-  <meta name="theme-color" content="#4e3075">
-</head>
-<body>
-    <div id='banner' class='content'>
-    blinkies.cafe
-    </div>
-    <div id='navbar' class='content'>
-        <a href='/'>generator</a> | <a href='/blog'>blog</a> | <a href='/archive'>archive</a><br>
-    </div><hr>
+<%- include('components/head.ejs', {
+    path: "wall", 
+    title: "the blinkie wall", 
+    description: "a searchable wall of all our blinkies."
+})%>
 <div class='content'>
     <h1>the blinkie wall</h1>
 </div>
@@ -42,7 +25,5 @@
     </div>
     </center>
 </div>
-<%- include('components/footer.html') %>
 <script src='/wall.js' type='module'></script>
-</body>
-</html>
+<%- include('components/footer.html') %>


### PR DESCRIPTION
(Based on #14)

## [Semantic HTML & skip link](https://github.com/piconaut/blinkies.cafe/commit/01084cb786c518ea608c52c285025f8c68f0acb2)
- Pages are now wrapped in `<main id="main">`
- A skip link is rendered with head for every page

## [Accessible actions and tiles](https://github.com/piconaut/blinkies.cafe/commit/9a2a6461e61f946542f5d187bcf60e200865a2d7)
- Added tabindex (and some role="button") to actions and clickable images/td's
- Created utils.js, which assists with combining onclick & onkeypress-enter
  Most onclicks have been adapted to use the help func
- cafe.ejs insertCharacter no-focus override for keyboard users